### PR TITLE
MauiMoneyMate: Add installer that installes the certificate and opens .msix

### DIFF
--- a/MauiMoneyMate/InstallerBase/MauiMoneyMate_0.0.0.0_x64_Installer.bat
+++ b/MauiMoneyMate/InstallerBase/MauiMoneyMate_0.0.0.0_x64_Installer.bat
@@ -1,0 +1,13 @@
+@echo off
+
+set "SCRIPT_DIR=%~dp0"
+set "CERT_FILE=%SCRIPT_DIR%MauiMoneyMate_0.0.0.0_x64\MauiMoneyMate_0.0.0.0_x64.cer"
+set "MSIX_FILE=%SCRIPT_DIR%MauiMoneyMate_0.0.0.0_x64\MauiMoneyMate_0.0.0.0_x64.msix"
+
+REM Import certificate to "Trusted People" store on local machine
+certutil -addstore "TrustedPeople" "%CERT_FILE%"
+
+REM Run the .msix file
+start "" "%MSIX_FILE%"
+
+echo Installation completed.


### PR DESCRIPTION
add general installer; names need to be adjusted depending on the version
Fixes #36