### PR TITLE
MauiMoneyMate: Add cleanup button on settings page

### DIFF
--- a/MauiMoneyMate/Pages/SettingsPage.xaml
+++ b/MauiMoneyMate/Pages/SettingsPage.xaml
@@ -65,26 +65,36 @@
                             SelectedIndex="{Binding CurrentTheme}">
                     </Picker>
                 </HorizontalStackLayout>
-                <Label Text="{Binding ElseLbl.Text}"
-                       FontSize="{Binding ElseLbl.FontSize}"
+                <Label Text="{Binding SystemLbl.Text}"
+                       FontSize="{Binding SystemLbl.FontSize}"
                        Style="{StaticResource LabelPrimary}"
                        Padding="0,40,0,0"/>
                 <HorizontalStackLayout Spacing="0"
                                        Padding="0">
-                <Button Text="{Binding ExportSettings.Text}"
-                        FontSize="{Binding ExportSettings.FontSize}"
-                        Clicked="ExportSettingsBtn_OnClicked"
-                        VerticalOptions="Center"
-                        HorizontalOptions="Start"
-                        Padding="9"
-                        Margin="5,5,5,5"/>
-                <Button Text="{Binding ImportSettings.Text}"
-                        FontSize="{Binding ImportSettings.FontSize}"
-                        Clicked="ImportSettingsBtn_OnClicked"
-                        VerticalOptions="Center"
-                        HorizontalOptions="Start"
-                        Padding="9"
-                        Margin="5,5,5,5"/>
+                    <Button Text="{Binding ExportSettingsBtn.Text}"
+                            FontSize="{Binding ExportSettingsBtn.FontSize}"
+                            Clicked="ExportSettingsBtn_OnClicked"
+                            VerticalOptions="Center"
+                            HorizontalOptions="Start"
+                            Padding="9"
+                            Margin="5,5,5,5"/>
+                    <Button Text="{Binding ImportSettingsBtn.Text}"
+                            FontSize="{Binding ImportSettingsBtn.FontSize}"
+                            Clicked="ImportSettingsBtn_OnClicked"
+                            VerticalOptions="Center"
+                            HorizontalOptions="Start"
+                            Padding="9"
+                            Margin="5,5,5,5"/>
+                </HorizontalStackLayout>
+                <HorizontalStackLayout Spacing="0"
+                                       Padding="0">
+                    <Button Text="{Binding DeleteTemporaryFilesBtn.Text}"
+                            FontSize="{Binding DeleteTemporaryFilesBtn.FontSize}"
+                            Clicked="DeleteTemporaryFilesBtn_OnClicked"
+                            VerticalOptions="Center"
+                            HorizontalOptions="Start"
+                            Padding="9"
+                            Margin="5,5,5,5"/>
                 </HorizontalStackLayout>
             </VerticalStackLayout>
         </ScrollView>

--- a/MauiMoneyMate/Pages/SettingsPage.xaml.cs
+++ b/MauiMoneyMate/Pages/SettingsPage.xaml.cs
@@ -39,4 +39,7 @@ public partial class SettingsPage : ContentPage
 
     private void ImportSettingsBtn_OnClicked(object sender, EventArgs e)
         => _viewModel.ImportSettingsBtn_OnClicked(sender, e);
+
+    private void DeleteTemporaryFilesBtn_OnClicked(object sender, EventArgs e)
+        => _viewModel.DeleteTemporaryFilesBtn_OnClicked(sender, e);
 }

--- a/MauiMoneyMate/Translations/LanguageResource.Designer.cs
+++ b/MauiMoneyMate/Translations/LanguageResource.Designer.cs
@@ -124,6 +124,15 @@ namespace MauiMoneyMate.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cleanup finished successfully.
+        /// </summary>
+        internal static string CleanupFinishedSuccessfully {
+            get {
+                return ResourceManager.GetString("CleanupFinishedSuccessfully", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not download update..
         /// </summary>
         internal static string CouldNotDownloadUpdate {
@@ -183,6 +192,24 @@ namespace MauiMoneyMate.Translations {
         internal static string DeleteBtn_Text {
             get {
                 return ResourceManager.GetString("DeleteBtn.Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 13.
+        /// </summary>
+        internal static string DeleteTemporaryFilesBtn_FontSize {
+            get {
+                return ResourceManager.GetString("DeleteTemporaryFilesBtn.FontSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete temporary system files.
+        /// </summary>
+        internal static string DeleteTemporaryFilesBtn_Text {
+            get {
+                return ResourceManager.GetString("DeleteTemporaryFilesBtn.Text", resourceCulture);
             }
         }
         
@@ -250,38 +277,29 @@ namespace MauiMoneyMate.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 30.
+        ///   Looks up a localized string similar to Error while deleting temporary files.
         /// </summary>
-        internal static string ElseLbl_FontSize {
+        internal static string ErrorWhileDeletingTemporaryFiles {
             get {
-                return ResourceManager.GetString("ElseLbl.FontSize", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Else.
-        /// </summary>
-        internal static string ElseLbl_Text {
-            get {
-                return ResourceManager.GetString("ElseLbl.Text", resourceCulture);
+                return ResourceManager.GetString("ErrorWhileDeletingTemporaryFiles", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to 13.
         /// </summary>
-        internal static string ExportSettings_FontSize {
+        internal static string ExportSettingsBtn_FontSize {
             get {
-                return ResourceManager.GetString("ExportSettings.FontSize", resourceCulture);
+                return ResourceManager.GetString("ExportSettingsBtn.FontSize", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Export settings.
         /// </summary>
-        internal static string ExportSettings_Text {
+        internal static string ExportSettingsBtn_Text {
             get {
-                return ResourceManager.GetString("ExportSettings.Text", resourceCulture);
+                return ResourceManager.GetString("ExportSettingsBtn.Text", resourceCulture);
             }
         }
         
@@ -432,18 +450,18 @@ namespace MauiMoneyMate.Translations {
         /// <summary>
         ///   Looks up a localized string similar to 13.
         /// </summary>
-        internal static string ImportSettings_FontSize {
+        internal static string ImportSettingsBtn_FontSize {
             get {
-                return ResourceManager.GetString("ImportSettings.FontSize", resourceCulture);
+                return ResourceManager.GetString("ImportSettingsBtn.FontSize", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Import settings.
         /// </summary>
-        internal static string ImportSettings_Text {
+        internal static string ImportSettingsBtn_Text {
             get {
-                return ResourceManager.GetString("ImportSettings.Text", resourceCulture);
+                return ResourceManager.GetString("ImportSettingsBtn.Text", resourceCulture);
             }
         }
         
@@ -849,6 +867,24 @@ namespace MauiMoneyMate.Translations {
         internal static string StartupLbl_Text {
             get {
                 return ResourceManager.GetString("StartupLbl.Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 30.
+        /// </summary>
+        internal static string SystemLbl_FontSize {
+            get {
+                return ResourceManager.GetString("SystemLbl.FontSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System.
+        /// </summary>
+        internal static string SystemLbl_Text {
+            get {
+                return ResourceManager.GetString("SystemLbl.Text", resourceCulture);
             }
         }
         

--- a/MauiMoneyMate/Translations/LanguageResource.de.resx
+++ b/MauiMoneyMate/Translations/LanguageResource.de.resx
@@ -288,13 +288,22 @@
   <data name="UseSystemTheme" xml:space="preserve">
     <value>Systemthema verwenden</value>
   </data>
-  <data name="ElseLbl.Text" xml:space="preserve">
+  <data name="SystemLbl.Text" xml:space="preserve">
     <value>Sonstiges</value>
   </data>
-  <data name="ExportSettings.Text" xml:space="preserve">
+  <data name="ExportSettingsBtn.Text" xml:space="preserve">
     <value>Einstellungen exportieren</value>
   </data>
-  <data name="ImportSettings.Text" xml:space="preserve">
+  <data name="ImportSettingsBtn.Text" xml:space="preserve">
     <value>Einstellungen importieren</value>
+  </data>
+  <data name="DeleteTemporaryFilesBtn.Text" xml:space="preserve">
+    <value>Temporäre Systemdateien löschen</value>
+  </data>
+  <data name="ErrorWhileDeletingTemporaryFiles" xml:space="preserve">
+    <value>Fehler beim Löschen temporärer Systemdateien</value>
+  </data>
+  <data name="CleanupFinishedSuccessfully" xml:space="preserve">
+    <value>Cleanup wurde erfolgreich beendet</value>
   </data>
 </root>

--- a/MauiMoneyMate/Translations/LanguageResource.resx
+++ b/MauiMoneyMate/Translations/LanguageResource.resx
@@ -435,22 +435,34 @@
   <data name="UseSystemTheme" xml:space="preserve">
     <value>Use system theme</value>
   </data>
-  <data name="ElseLbl.FontSize" xml:space="preserve">
+  <data name="SystemLbl.FontSize" xml:space="preserve">
     <value>30</value>
   </data>
-  <data name="ElseLbl.Text" xml:space="preserve">
-    <value>Else</value>
+  <data name="SystemLbl.Text" xml:space="preserve">
+    <value>System</value>
   </data>
-  <data name="ExportSettings.FontSize" xml:space="preserve">
+  <data name="ExportSettingsBtn.FontSize" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="ExportSettings.Text" xml:space="preserve">
+  <data name="ExportSettingsBtn.Text" xml:space="preserve">
     <value>Export settings</value>
   </data>
-  <data name="ImportSettings.FontSize" xml:space="preserve">
+  <data name="ImportSettingsBtn.FontSize" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="ImportSettings.Text" xml:space="preserve">
+  <data name="ImportSettingsBtn.Text" xml:space="preserve">
     <value>Import settings</value>
+  </data>
+  <data name="DeleteTemporaryFilesBtn.FontSize" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="DeleteTemporaryFilesBtn.Text" xml:space="preserve">
+    <value>Delete temporary system files</value>
+  </data>
+  <data name="ErrorWhileDeletingTemporaryFiles" xml:space="preserve">
+    <value>Error while deleting temporary files</value>
+  </data>
+  <data name="CleanupFinishedSuccessfully" xml:space="preserve">
+    <value>Cleanup finished successfully</value>
   </data>
 </root>

--- a/MauiMoneyMate/Utils/CommonFunctions.cs
+++ b/MauiMoneyMate/Utils/CommonFunctions.cs
@@ -123,4 +123,22 @@ internal static class CommonFunctions
         CommonProperties.Settings.ReadXml(result);
         return true;
     }
+
+    internal static bool ClearTemporaryFiles()
+    {
+        try
+        {
+            foreach (var directory in CommonProperties.DirectoriesWithTemporaryFiles)
+            {
+                if (!Directory.Exists(directory)) return true;
+                Directory.Delete(directory, true);
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/MauiMoneyMate/Utils/CommonProperties.cs
+++ b/MauiMoneyMate/Utils/CommonProperties.cs
@@ -124,6 +124,10 @@ internal static class CommonProperties
             UpdateSettings(DesignSettings, nameof(CurrentAppTheme), Convert.ToString(value));
         }
     }
+    internal static List<string> DirectoriesWithTemporaryFiles { get; } = new()
+    {
+        UpdateDirectory
+    };
 
     internal static bool UpdateAvailable { get; set; } = false;
 

--- a/MauiMoneyMate/ViewModels/SettingsViewModel.cs
+++ b/MauiMoneyMate/ViewModels/SettingsViewModel.cs
@@ -40,11 +40,13 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty] private int _currentTheme;
 
-    [ObservableProperty] private ResourceLabel _elseLbl;
+    [ObservableProperty] private ResourceLabel _systemLbl;
 
-    [ObservableProperty] private ResourceButton _exportSettings;
+    [ObservableProperty] private ResourceButton _exportSettingsBtn;
 
-    [ObservableProperty] private ResourceButton _importSettings;
+    [ObservableProperty] private ResourceButton _importSettingsBtn;
+
+    [ObservableProperty] private ResourceButton _deleteTemporaryFilesBtn;
 
     #endregion
 
@@ -147,6 +149,15 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
+    internal void DeleteTemporaryFilesBtn_OnClicked(object sender, EventArgs e)
+    {
+        Toast.Make(
+            CommonFunctions.ClearTemporaryFiles()
+                ? LanguageResource.CleanupFinishedSuccessfully
+                : LanguageResource.ErrorWhileDeletingTemporaryFiles
+                ).Show();
+    }
+
     #endregion
 
     #region private Methods
@@ -173,9 +184,10 @@ public partial class SettingsViewModel : ObservableObject
             LanguageResource.Light,
             LanguageResource.Dark
         };
-        ElseLbl = new ResourceLabel(nameof(ElseLbl));
-        ExportSettings = new ResourceButton(nameof(ExportSettings));
-        ImportSettings = new ResourceButton(nameof(ImportSettings));
+        SystemLbl = new ResourceLabel(nameof(SystemLbl));
+        ExportSettingsBtn = new ResourceButton(nameof(ExportSettingsBtn));
+        ImportSettingsBtn = new ResourceButton(nameof(ImportSettingsBtn));
+        DeleteTemporaryFilesBtn = new ResourceButton(nameof(DeleteTemporaryFilesBtn));
     }
 
     #endregion


### PR DESCRIPTION
Fixes #80
* Implement button that deletes temporary files created but not necessarily needed by the system